### PR TITLE
Keep sort order between saves

### DIFF
--- a/InputfieldSelectImages.module
+++ b/InputfieldSelectImages.module
@@ -98,6 +98,12 @@ class InputfieldSelectImages extends InputfieldSelectMultiple {
 	public function ___render() {
 		$options = $this->options;
 
+		// Keep current sort order from values
+		$this->options = array_merge(
+			array_flip($this->value ?: []),
+			$this->options
+		);
+
 		// Selected images
 		$out = parent::___render();
 		$out .= "<div class='selected-images'>";

--- a/InputfieldSelectImages.module
+++ b/InputfieldSelectImages.module
@@ -6,7 +6,7 @@ class InputfieldSelectImages extends InputfieldSelectMultiple {
 		return array(
 			'title' => 'Select Images',
 			'summary' => 'An inputfield that allows the visual selection and sorting of images, intended for use with FieldtypeDynamicOptions.',
-			'version' => '0.1.3',
+			'version' => '0.1.4',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/InputfieldSelectImages',
 			'icon' => 'picture-o',


### PR DESCRIPTION
Pre-sort available options by the order of the current saved values, preventing the order getting lost when the field isn't interacted with and no JS is executed. The visual order of selectable images stays the same, only the order of the invisible select options is affected.

Should fix #3.